### PR TITLE
Add Chrome side panel extension

### DIFF
--- a/notion-side-panel/README.md
+++ b/notion-side-panel/README.md
@@ -1,0 +1,11 @@
+# Notion Side Panel Extension
+
+This Chrome extension opens a web page inside Chrome's side panel. It remembers the last page you visited so that the next time you open the panel you return to that page.
+
+## Usage
+1. Load the extension in Chrome by navigating to `chrome://extensions` and enabling **Developer mode**.
+2. Click **Load unpacked** and select this `notion-side-panel` folder.
+3. Click the extension's toolbar icon to open the side panel.
+4. Use the text field at the top to enter a new URL if desired. The last URL is stored in browser storage.
+
+By default, it loads the provided Notion page.

--- a/notion-side-panel/background.js
+++ b/notion-side-panel/background.js
@@ -1,0 +1,3 @@
+chrome.action.onClicked.addListener((tab) => {
+  chrome.sidePanel.open({ tabId: tab.id });
+});

--- a/notion-side-panel/manifest.json
+++ b/notion-side-panel/manifest.json
@@ -1,0 +1,16 @@
+{
+  "name": "Notion Side Panel",
+  "description": "Open a webpage in the Chrome side panel and remember the last URL.",
+  "version": "1.0",
+  "manifest_version": 3,
+  "action": {
+    "default_title": "Open Side Panel"
+  },
+  "background": {
+    "service_worker": "background.js"
+  },
+  "permissions": ["storage", "sidePanel"],
+  "side_panel": {
+    "default_path": "panel.html"
+  }
+}

--- a/notion-side-panel/panel.html
+++ b/notion-side-panel/panel.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Notion Panel</title>
+    <style>
+      html, body { height: 100%; margin: 0; }
+      #urlInput { width: 100%; box-sizing: border-box; }
+      #viewer { width: 100%; height: calc(100% - 30px); border: none; }
+    </style>
+  </head>
+  <body>
+    <input id="urlInput" type="text" />
+    <iframe id="viewer"></iframe>
+    <script src="panel.js"></script>
+  </body>
+</html>

--- a/notion-side-panel/panel.js
+++ b/notion-side-panel/panel.js
@@ -1,0 +1,13 @@
+document.addEventListener('DOMContentLoaded', async () => {
+  const input = document.getElementById('urlInput');
+  const frame = document.getElementById('viewer');
+  const { lastUrl } = await chrome.storage.local.get({ lastUrl: 'https://www.notion.so/kmle/note-208b35c8bd6580b9a097c311507b129e' });
+  input.value = lastUrl;
+  frame.src = lastUrl;
+
+  input.addEventListener('change', () => {
+    const url = input.value.trim();
+    frame.src = url;
+    chrome.storage.local.set({ lastUrl: url });
+  });
+});


### PR DESCRIPTION
## Summary
- create a Chrome extension to open a webpage in Chrome's side panel
- remember the last page visited using storage
- document how to load and use the extension

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68400f59ab388320bead353c3b098553