### PR TITLE
Add popup panel window for Notion

### DIFF
--- a/notion-side-panel/README.md
+++ b/notion-side-panel/README.md
@@ -1,0 +1,9 @@
+# Notion Panel Window Extension
+
+This Chrome extension opens a narrow window on the right side of the screen and loads a web page. The extension remembers the page you last viewed so reopening the panel restores that page.
+
+## Usage
+1. Navigate to `chrome://extensions` and enable **Developer mode**.
+2. Choose **Load unpacked** and select this `notion-side-panel` folder.
+3. Click the extension's icon to open the Notion panel. A popup window appears on the right showing the previously visited page (the first time it opens the provided Notion link).
+4. Browse normally inside that window. Any navigation will be saved and restored the next time the panel is opened.

--- a/notion-side-panel/background.js
+++ b/notion-side-panel/background.js
@@ -1,0 +1,52 @@
+const defaultUrl =
+  'https://www.notion.so/kmle/note-208b35c8bd6580b9a097c311507b129e';
+let panelWindowId = null;
+
+async function createPanel(url) {
+  const [display] = await chrome.system.display.getInfo();
+  const { width, height } = display.workArea;
+  const panelWidth = 400;
+  return new Promise((resolve) => {
+    chrome.windows.create(
+      {
+        url,
+        type: 'popup',
+        width: panelWidth,
+        height,
+        left: width - panelWidth,
+        top: 0,
+      },
+      (win) => {
+        panelWindowId = win.id;
+        resolve(win);
+      },
+    );
+  });
+}
+
+chrome.action.onClicked.addListener(async () => {
+  if (panelWindowId) {
+    try {
+      await chrome.windows.update(panelWindowId, { focused: true });
+      return;
+    } catch (e) {
+      panelWindowId = null;
+    }
+  }
+
+  const { lastUrl = defaultUrl } = await chrome.storage.local.get('lastUrl');
+  await createPanel(lastUrl);
+
+  chrome.windows.onRemoved.addListener(function listener(id) {
+    if (id === panelWindowId) {
+      panelWindowId = null;
+      chrome.windows.onRemoved.removeListener(listener);
+    }
+  });
+});
+
+chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+  if (tab.windowId === panelWindowId && changeInfo.url) {
+    chrome.storage.local.set({ lastUrl: changeInfo.url });
+  }
+});

--- a/notion-side-panel/manifest.json
+++ b/notion-side-panel/manifest.json
@@ -1,0 +1,13 @@
+{
+  "name": "Notion Panel Window",
+  "description": "Open a webpage in a panel-like window and remember the last visited page.",
+  "version": "1.0",
+  "manifest_version": 3,
+  "action": {
+    "default_title": "Open Notion Panel"
+  },
+  "background": {
+    "service_worker": "background.js"
+  },
+  "permissions": ["storage", "windows", "system.display", "tabs"]
+}


### PR DESCRIPTION
## Summary
- refactor extension to open Notion URL in a popup window at the screen's right side
- remember the last visited URL and restore it when reopening
- update manifest permissions for windows API and remove side panel files
- document how to load and use the new popup panel

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68400f59ab388320bead353c3b098553